### PR TITLE
Minor fixes and improvements in various places

### DIFF
--- a/apple/TasteNotes/Repositories/FriendsRepository.swift
+++ b/apple/TasteNotes/Repositories/FriendsRepository.swift
@@ -21,7 +21,13 @@ struct SupabaseFriendsRepository: FriendRepository {
         .or(filters: "user_id_1.eq.\(userId),user_id_2.eq.\(userId)")
 
       if let status {
-        queryBuilder = queryBuilder.eq(column: "status", value: status.rawValue)
+        switch status {
+        case .blocked:
+          queryBuilder = queryBuilder.eq(column: "status", value: status.rawValue)
+            .eq(column: "blocked_by", value: userId)
+        default:
+          queryBuilder = queryBuilder.eq(column: "status", value: status.rawValue)
+        }
       } else {
         queryBuilder = queryBuilder.not(column: "status", operator: .eq, value: Friend.Status.blocked.rawValue)
       }

--- a/apple/TasteNotes/UI/Screens/BlockedUsersScreenView.swift
+++ b/apple/TasteNotes/UI/Screens/BlockedUsersScreenView.swift
@@ -35,7 +35,6 @@ struct BlockedUsersScreenView: View {
               }
             }
           }
-
         })
       }
       .presentationDetents([.medium])

--- a/apple/TasteNotes/UI/Screens/CompanyScreenView.swift
+++ b/apple/TasteNotes/UI/Screens/CompanyScreenView.swift
@@ -165,7 +165,7 @@ struct CompanyScreenView: View {
         .headerProminence(.increased)
         .confirmationDialog("Delete Brand Confirmation",
                             isPresented: $showDeleteBrandConfirmationDialog) {
-          Button("Delete Brand", role: .destructive, action: { viewModel.deleteBrand(brand) })
+          Button("Delete \(brand.name) brand", role: .destructive, action: { viewModel.deleteBrand(brand) })
         }
       }
     }

--- a/apple/TasteNotes/UI/Screens/CompanyScreenView.swift
+++ b/apple/TasteNotes/UI/Screens/CompanyScreenView.swift
@@ -130,7 +130,7 @@ struct CompanyScreenView: View {
                     }) {
                       Label("Delete", systemImage: "trash.fill")
                         .foregroundColor(.red)
-                    }
+                    }.disabled(product.isVerified)
                   }
                 }
               }
@@ -155,7 +155,7 @@ struct CompanyScreenView: View {
                   showDeleteBrandConfirmationDialog.toggle()
                 }) {
                   Label("Delete", systemImage: "trash.fill")
-                }
+                }.disabled(brand.isVerified)
               }
             } label: {
               Image(systemName: "ellipsis")

--- a/apple/TasteNotes/UI/Screens/FriendsScreenView.swift
+++ b/apple/TasteNotes/UI/Screens/FriendsScreenView.swift
@@ -60,8 +60,8 @@ struct FriendsScreenView: View {
           }
           .errorAlert(error: $viewModel.modalError)
         })
-        .presentationDetents([.medium])
       }
+      .presentationDetents([.medium])
     }
     .errorAlert(error: $viewModel.error)
     .confirmationDialog("delete_friend",

--- a/apple/TasteNotes/UI/Screens/ProductScreenView.swift
+++ b/apple/TasteNotes/UI/Screens/ProductScreenView.swift
@@ -106,6 +106,7 @@ struct ProductScreenView: View {
           viewModel.showDeleteConfirmation()
         }) {
           Label("Delete", systemImage: "trash.fill")
+            .disabled(product.isVerified)
         }
       }
     }

--- a/apple/TasteNotes/UI/Sheets/CheckInSheetView.swift
+++ b/apple/TasteNotes/UI/Sheets/CheckInSheetView.swift
@@ -206,8 +206,7 @@ struct CheckInSheetView: View {
       leading: Button(action: {
         dismiss()
       }) {
-        Text("Cancel")
-          .bold()
+        Text("Cancel").bold()
       },
       trailing: Button(action: {
         switch action {

--- a/apple/TasteNotes/UI/Sheets/EditBrandSheetView.swift
+++ b/apple/TasteNotes/UI/Sheets/EditBrandSheetView.swift
@@ -70,6 +70,7 @@ struct EditBrandSheetView: View {
                   viewModel.toDeleteSubBrand = subBrand
                 }) {
                   Label("Delete", systemImage: "trash")
+                    .disabled(subBrand.isVerified)
                 }
               } label: {
                 Image(systemName: "ellipsis")

--- a/apple/TasteNotes/UI/Sheets/ProductSheetView.swift
+++ b/apple/TasteNotes/UI/Sheets/ProductSheetView.swift
@@ -100,9 +100,8 @@ struct ProductSheetView: View {
           BarcodeScannerSheetView(onComplete: {
             barcode in viewModel.barcode = barcode
           })
-          .presentationDetents([.medium])
         }
-      }
+      }.if(sheet == .barcode, transform: { view in view.presentationDetents([.medium]) })
     }
     .task {
       if let initialProduct {

--- a/apple/TasteNotes/UI/Sheets/UserSheetView.swift
+++ b/apple/TasteNotes/UI/Sheets/UserSheetView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct UserSheetView<Actions: View>: View {
   @StateObject private var viewModel = ViewModel()
+  @Environment(\.dismiss) private var dismiss
 
   let actions: (_ profile: Profile) -> Actions
 
@@ -19,6 +20,11 @@ struct UserSheetView<Actions: View>: View {
       }
     }
     .navigationTitle("Search users")
+    .navigationBarItems(trailing: Button(action: {
+      dismiss()
+    }) {
+      Text("Cancel").bold()
+    })
     .searchable(text: $viewModel.searchText)
     .onSubmit(of: .search) { viewModel.searchUsers() }
   }

--- a/apple/TasteNotes/UI/Tabs/SearchTabView.swift
+++ b/apple/TasteNotes/UI/Tabs/SearchTabView.swift
@@ -69,8 +69,8 @@ struct SearchTabView: View {
               BarcodeScannerSheetView(onComplete: {
                 barcode in viewModel.searchProductsByBardcode(barcode)
               })
-              .presentationDetents([.medium])
             }
+            .presentationDetents([.medium])
           }
           .searchable(text: $viewModel.searchTerm, tokens: $viewModel.tokens) { token in
             switch token {


### PR DESCRIPTION
- Fix issue where the blocked users page showed the person who had blocked the current user
- Make it possible to block users from the current users page
- Fix the use of presentationDetents that was broken when NavigationStack was moved out from the sheets, now all modals use the correct size again
-  Add brand name to the delete confirmation dialogs
- Disable delete buttons for verified items (products, brands, sub-brands)